### PR TITLE
Update GridColumnCommandItem to match types/example from documentation.

### DIFF
--- a/types/kendo-ui/index.d.ts
+++ b/types/kendo-ui/index.d.ts
@@ -3707,7 +3707,7 @@ declare namespace kendo.ui {
     interface GridColumnCommandItem {
         visible?: Function;
         name?: string;
-        text?: GridColumnCommandItemText;
+        text?: string|GridColumnCommandItemText;
         className?: string;
         click?: Function;
         iconClass?: string;


### PR DESCRIPTION
- GridColumnCommandItem has been changed from only accepting GridColumnCommandItemText to accepting both string or GridColumnCommandItemText.

Please fill in this template.

- [X ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ X] Test the change in your own code. (Compile and run.)
- [X ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X ] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.telerik.com/kendo-ui/api/javascript/ui/grid#configuration-columns.command.text
